### PR TITLE
fixed ValueError for MST and fixed SnytaxErrors

### DIFF
--- a/mistree/mst/branches.py
+++ b/mistree/mst/branches.py
@@ -80,14 +80,14 @@ def get_branch_index(edge_index, edge_degree, branch_cutting_frequency=1000):
                         done = 1.
                     else:
                         check_end[condition] = 0.
-                        _twig.append(index_branch_end[condition])
+                        _twig.append(index_branch_end[condition][0])
                         done = 1.
                         mask_end[condition] = False
                         branch_index.append(np.ndarray.tolist(np.ndarray.flatten(np.array(_twig))))
                 else:
                     if len(condition) == 1:
                         check_mid[condition] = 0.
-                        _twig.append(index_branch_mid[condition])
+                        _twig.append(index_branch_mid[condition][0])
                         if index_branch_mid1[condition] == node_index:
                             node_index = index_branch_mid2[condition]
                         elif index_branch_mid2[condition] == node_index:
@@ -241,7 +241,7 @@ def get_branch_index_sub_divide(sub_divisions, edge_index, edge_degree, box_size
         branch_index_cut_corrected = [np.ndarray.tolist(condition[i]) for i in branch_index_cut]
         branch_index_total = branch_index_total + branch_index_cut_corrected
         total_mask[[item for sublist in branch_index_total for item in sublist]] = 0.
-        if len(branch_index_rejected_cut) is not 0:
+        if len(branch_index_rejected_cut) != 0:
             branch_index_rejected_total = branch_index_rejected_total + \
                                           np.ndarray.tolist(condition[branch_index_rejected_cut])
         total_mask[branch_index_rejected_total] = 0.

--- a/mistree/mst/get_mst_class.py
+++ b/mistree/mst/get_mst_class.py
@@ -194,15 +194,15 @@ class GetMST:
             The number of divisions used to divide the data set in each axis. Used for speeding up the branch
             finding algorithm when using many points (> 100000).
         """
-        if sub_divisions is 1:
+        if sub_divisions == 1:
             branch_index, rejected_branch_index = branches.get_branch_index(self.edge_index, self.edge_degree)
         else:
-            if self._mode is '2D':
+            if self._mode == '2D':
                 branch_index, rejected_branch_index = \
                     branches.get_branch_index_sub_divide(sub_divisions, self.edge_index, self.edge_degree,
                                                          box_size=box_size, edge_x=self.edge_x, edge_y=self.edge_y,
                                                          mode='Euclidean', two_dimension=True)
-            elif self._mode is '3D':
+            elif self._mode == '3D':
                 branch_index, rejected_branch_index = \
                     branches.get_branch_index_sub_divide(sub_divisions, self.edge_index, self.edge_degree,
                                                          box_size=box_size, edge_x=self.edge_x, edge_y=self.edge_y,
@@ -213,7 +213,7 @@ class GetMST:
                                                          box_size=None, phi=self.phi, theta=self.theta,
                                                          edge_phi=self.edge_phi, edge_theta=self.edge_theta, mode='spherical')
         self.branch_index = branch_index
-        if len(rejected_branch_index) is not 0:
+        if len(rejected_branch_index) != 0:
             if self.do_print is True:
                 print(str(float(len(rejected_branch_index))) + ' branches were incompleted.')
         branch_length = [np.sum(self.edge_length[i]) for i in branch_index]


### PR DESCRIPTION
* Fix Error for creating a MST in python greater than 3.7. in Branches.py the following error occurs:

```python
  File "~/mistree/mistree/mst/get_mst_class.py", line 198, in get_branches
    branch_index, rejected_branch_index = branches.get_branch_index(self.edge_index, self.edge_degree)
  File "~/mistree/mistree/mst/branches.py", line 86, in get_branch_index
    branch_index.append(np.ndarray.tolist(np.ndarray.flatten(np.array(_twig))))
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (6,) + inhomogeneous part.
```

All pytest pass after change.

* Fixing SyntaxError for ``` is in ``` and ``` is``` to ``` !=``` and ``` ==```